### PR TITLE
130 criar testes unitários

### DIFF
--- a/codigo-fonte/backend/safeWorkApi/Controller/LoginController.cs
+++ b/codigo-fonte/backend/safeWorkApi/Controller/LoginController.cs
@@ -36,7 +36,7 @@ namespace safeWorkApi.Controller
                 string.IsNullOrWhiteSpace(model.Senha)))
                 return Unauthorized(new { message = "Email e senha são obrigatórios" });
 
-            Usuario? usuarioDb = await _context.Usuarios.AsNoTracking()
+            Usuario? usuarioDb = await _context.Usuarios
                 .Include(u => u.Perfil)
                 .FirstOrDefaultAsync(c => c.Email == model.Email);
 
@@ -125,7 +125,7 @@ namespace safeWorkApi.Controller
                 return StatusCode(422, "Dados de email inválidos");
 
             var user = await _context.Usuarios
-                .AsNoTracking().FirstOrDefaultAsync(u => u.Email == email);
+                .FirstOrDefaultAsync(u => u.Email == email);
 
             if (user == null)
                 return StatusCode(422, "Usuário não cadastrado");
@@ -158,7 +158,7 @@ namespace safeWorkApi.Controller
                 return StatusCode(400, "Dados não fornecidos");
 
             var userDb = await _context.Usuarios
-                .AsNoTracking().FirstOrDefaultAsync(u => u.Email == model.Email);
+                .FirstOrDefaultAsync(u => u.Email == model.Email);
 
             if (userDb == null)
                 return StatusCode(422, "Usuário não pertence ao site");


### PR DESCRIPTION
Adiciona testes unitários para as rotas RecoverPassword e ResetPassword, cobrindo cenários de modelo inválido, usuário inexistente, token inválido e fluxo completo de redefinição de senha.
Também ajusta o LoginController removendo AsNoTracking() para permitir atualização correta no EF InMemory durante os testes.